### PR TITLE
Update @nestjs/common to v11.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5528,9 +5528,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.0.10",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.10.tgz",
-      "integrity": "sha512-pzGXp14KF2Q4CDZGQgPK4l8zEg7i6cNkb+10yc8ZA5K41cLe3ZbWW1YxtY2e/glHauOJwTLSVjH4tiRVtOTizg==",
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.12.tgz",
+      "integrity": "sha512-6PXxmDe2iYmb57xacnxzpW1NAxRZ7Gf+acMT7/hmRB/4KpZiFU/cNvLWwgbM2BL5QSzQulOwY6ny5bbKnPpB+A==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",


### PR DESCRIPTION
### Description

This pull request updates the `@nestjs/common` dependency from version `11.0.10` to `11.0.12` in the `package-lock.json` file. This ensures the project benefits from the latest bug fixes and improvements in the package.